### PR TITLE
Fix for handling larger numbers in BigInt columns

### DIFF
--- a/packages/prisma-adapter/src/conversion.ts
+++ b/packages/prisma-adapter/src/conversion.ts
@@ -333,6 +333,7 @@ function convertBytes(serializedBytes: string): number[] {
 }
 
 export const customParsers: ParserOptions = {
+	[ScalarColumnType.INT8]: normalize_numeric,
 	[ScalarColumnType.NUMERIC]: normalize_numeric,
 	[ScalarColumnType.TIME]: normalize_time,
 	[ScalarColumnType.TIMETZ]: normalize_timez,

--- a/sandbox/prisma/migration.sql
+++ b/sandbox/prisma/migration.sql
@@ -48,7 +48,7 @@ CREATE TABLE "type_test_2" (
     "id" TEXT NOT NULL,
     "datetime_column" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "datetime_column_null" TIMESTAMP(3),
-
+    "bigint_column" BIGINT NOT NULL DEFAULT 0,
     CONSTRAINT "type_test_2_pkey" PRIMARY KEY ("id")
 );
 

--- a/sandbox/prisma/schema.prisma
+++ b/sandbox/prisma/schema.prisma
@@ -50,6 +50,7 @@ model type_test_2 {
   id                   String    @id @default(cuid())
   datetime_column      DateTime  @default(now()) @db.Timestamp(3)
   datetime_column_null DateTime? @db.Timestamp(3)
+  bigint_column        BigInt    @default(0)
 }
 
 model Child {

--- a/sandbox/src/test.ts
+++ b/sandbox/src/test.ts
@@ -24,6 +24,7 @@ export async function smokeTest(adapter: DriverAdapter) {
   await test.testCreateAndDeleteChildParent();
   await test.interactiveTransactions();
   await test.explicitTransaction();
+  await test.testBigInt();
 
   console.log("[nodejs] disconnecting...");
   await prisma.$disconnect();
@@ -239,5 +240,20 @@ class SmokeTest {
       "[nodejs] resultDeleteMany",
       superjson.serialize(resultDeleteMany).json
     );
+  }
+
+  async testBigInt() {
+    const result = await this.prisma.type_test_2.create({
+      data: {
+        bigint_column: 9223372036854775807n,
+      },
+    });
+
+
+    if (typeof result.bigint_column === "bigint") {
+      console.log("[nodejs] bigint_column is a bigint");
+    }
+
+    console.log("[nodejs] testBigInt result", superjson.serialize(result).json);
   }
 }


### PR DESCRIPTION
Regarding #22 

Adds support for correctly passing larger numbers to BigInt columns without converting them into float strings. This prevents the `Conversion failed: number must be an integer in column 'bigint_column', got '17435114878.0'` when working with values like 17435114878.